### PR TITLE
Fix default setup

### DIFF
--- a/bin/run
+++ b/bin/run
@@ -3,7 +3,10 @@
 const readPkg = require('read-pkg')
 const runTest = require('../lib/index')
 
-process.env.SELF_START = false
+if (process.env.SELF_START &&
+    process.env.SELF_START.toLowerCase().trim() in ['false', 'null', 'undefined', '']) {
+  delete process.env.SELF_START
+}
 
 const pkg = readPkg.sync(process.cwd())
 const config = pkg.jest


### PR DESCRIPTION
This patch deletes `process.env.SELF_STARTUP` if it's defined as a falsy string (i.e., `"null"`, `"undefined"`, `""`, `"false"`). Otherwise, the string is incorrectly treated as `true`, which prevents the setup of Nuxt and various test globals.

Fixes #1