### PR TITLE
Disable bundle analyzer

### DIFF
--- a/lib/setup.js
+++ b/lib/setup.js
@@ -15,6 +15,9 @@ const initNuxt = async () => {
     throw Error('Couldn\'t find nuxt.js config')
   }
   config.rootDir = rootDir
+  if (config.build && config.build.analyze) {
+    delete config.build.analyze;
+  }
   config.dev = false
   const nuxt = new Nuxt(config)
   await new Builder(nuxt).build()


### PR DESCRIPTION
This patch updates the default setup to disable the bundle analyzer (i.e. from Nuxt config's `build.analyze`), as it's an unnecessary when building tests.